### PR TITLE
Corrected HGVS construction to always correspond to coding strand

### DIFF
--- a/lib/data_fetchers/hgvs.rb
+++ b/lib/data_fetchers/hgvs.rb
@@ -11,10 +11,16 @@ module DataFetchers
 
     #{transcript_name}:{c_position}{reference}>{variant}
     def self.get_hgvs_from_variant(variant)
-      send("#{variant.variant_type.name.downcase}_template", variant)
+      if variant.strand == "+1"
+        puts "+ strand"
+        send("#{variant.variant_type.name.downcase}_plus_strand_template", variant)
+      else
+        puts "- strand"
+        send("#{variant.variant_type.name.downcase}_minus_strand_template", variant)
+      end
     end
 
-    def self.snp_template(variant)
+    def self.snp_plus_strand_template(variant)
       sprintf("%s:%s%s>%s",
               variant.transcript.name,
               variant.cdna_change,
@@ -22,23 +28,54 @@ module DataFetchers
               variant.variant)
     end
 
-    def self.dnp_template(variant)
-      snp_template(variant)
+    def self.dnp_plus_strand_template(variant)
+      snp_plus_strand_template(variant)
     end
 
-    def self.del_template(variant)
+    def self.del_plus_strand_template(variant)
       sprintf("%s:%sdel%s",
               variant.transcript.name,
               variant.cdna_change,
               variant.location.reference_read)
     end
 
-    def self.ins_template(variant)
+    def self.ins_plus_strand_template(variant)
       sprintf("%s:%sins%s",
               variant.transcript.name,
               variant.cdna_change,
               variant.variant)
     end
+
+    def self.snp_minus_strand_template(variant)
+      sprintf("%s:%s%s>%s",
+              variant.transcript.name,
+              variant.cdna_change,
+              reverse_complement(variant.location.reference_read),
+              reverse_complement(variant.variant))
+    end
+
+    def self.dnp_minus_strand_template(variant)
+      snp_minus_strand_template(variant)
+    end
+
+    def self.del_minus_strand_template(variant)
+      sprintf("%s:%sdel%s",
+              variant.transcript.name,
+              variant.cdna_change,
+              reverse_complement(variant.location.reference_read))
+    end
+
+    def self.ins_minus_strand_template(variant)
+      sprintf("%s:%sins%s",
+              variant.transcript.name,
+              variant.cdna_change,
+              reverse_complement(variant.variant))
+    end
+
+    def self.reverse_complement(seq)
+      return seq.reverse().tr!('ATCGatcg','TAGCtagc')
+    end
+
   end
 end
 

--- a/lib/data_fetchers/hgvs.rb
+++ b/lib/data_fetchers/hgvs.rb
@@ -73,7 +73,7 @@ module DataFetchers
     end
 
     def self.reverse_complement(seq)
-      return seq.reverse().tr!('ATCGatcg','TAGCtagc')
+      seq.reverse().tr('ATCGatcg','TAGCtagc')
     end
 
   end


### PR DESCRIPTION
This PR intends to fix issue #16.

@acoffman would it be best to wait and merge this PR until the versioning system is finished?