### PR TITLE
Ruby version update

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,10 @@ script:
   - bundle exec rake spec
 rvm:
   - "2.1.0"
+  - "1.9.3"
+  - "2.0.0"
+  - "2.2.0"
+  - "2.3.0"
 env:
   - RAILS_ENV=test TRAVIS_BUILD=true
 notifications:

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,6 @@ script:
   - bundle exec rake spec
 rvm:
   - "2.1.0"
-  - "1.9.3"
   - "2.0.0"
   - "2.2.0"
   - "2.3.0"

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -1,6 +1,6 @@
 Prerequisites
 ----
-* Ruby (= 2.1.0)
+* Ruby (>= 2.0.0)
 * Postgres (>= 9)
 * Bundler
 

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -1,6 +1,6 @@
 Prerequisites
 ----
-* Ruby (>= 1.9.3)
+* Ruby (= 2.1.0)
 * Postgres (>= 9)
 * Bundler
 
@@ -30,8 +30,7 @@ Note: if nokogiri fails to build, after "cd docm", run this command:
     bundle exec rake db:drop
     bundle exec rake db:create
     bundle exec rake db:migrate
-    bundle exec rake docm:import['/path/to/data.tsv']
-    rails s
+    bundle exec rake docm:load
 
 
 The application will be reachable at `http://localhost:3000`

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -31,6 +31,7 @@ Note: if nokogiri fails to build, after "cd docm", run this command:
     bundle exec rake db:create
     bundle exec rake db:migrate
     bundle exec rake docm:load
+    rails s
 
 
 The application will be reachable at `http://localhost:3000`

--- a/app/views/static/batch_submission_help.html.haml
+++ b/app/views/static/batch_submission_help.html.haml
@@ -30,25 +30,25 @@
               %tr
                 %td start
                 %td
-                  Starting position of the variant
+                  Genomic starting position of the variant
                   %small (required)
                 %tr
                   %td
                     stop
                   %td
-                    End position of the variant
+                    Genomic end position of the variant
                     %small (required)
                 %tr
                   %td
                     reference
                   %td
-                    Reference bases. "None" should be represented with a "-" character
+                    Reference bases (genomic '+' strand). "None" should be represented with a "-" character
                     %small (required)
                 %tr
                   %td
                     variant
                   %td
-                    Variant bases. "None" should be represented with a "-" character
+                    Variant bases (genomic '+' strand). "None" should be represented with a "-" character
                     %small (required)
                 %tr
                   %td


### PR DESCRIPTION
Tried installing docm with Ruby 1.9.3, it failed. Updated install directions and travis.yml to specify Ruby >= 2.0.0. Also, changed instructions to use docm:load instead of docm:import.